### PR TITLE
Fixed wickedpicker not displaying 'now' value when initialised

### DIFF
--- a/src/wickedpicker.js
+++ b/src/wickedpicker.js
@@ -75,6 +75,7 @@
         this.selectedMeridiem = this.parseMeridiem(this.options.now.getHours());
         this.setHoverState();
         this.attach(element);
+        this.setText(element);
     }
 
     $.extend(Wickedpicker.prototype, {


### PR DESCRIPTION
During initialisation, wickedpicker does not set text to the element.
So, the 'now' option value will not be displayed, until user clicks the
element.

For example,
```
	var options = {
		now: "12:35",
		twentyFour: false
	};
	$('.timepicker').wickedpicker(options);
```

During the first load, wickedpicker will not show _'12:35 PM'_.
But when user clicks the element, it will now show _'12:35 PM'_.